### PR TITLE
Fix `cargo-generate` arguments and binary URL

### DIFF
--- a/src/run/new.rs
+++ b/src/run/new.rs
@@ -54,6 +54,7 @@ impl NewCommand {
         let args = self.to_args();
         let exe = cargo_generate_exe()?;
         let mut process = Command::new(exe)
+            .arg("generate")
             .args(&args)
             .spawn()
             .context("Could not spawn command")?;
@@ -80,9 +81,11 @@ fn bool_push(args: &mut Vec<String>, name: &str, set: bool) {
         args.push(format!("--{name}"))
     }
 }
+
 fn opt_push(args: &mut Vec<String>, name: &str, arg: &Option<String>) {
     if let Some(arg) = arg {
-        args.push(format!("--{name} {arg}"));
+        args.push(format!("--{name}"));
+        args.push(arg.clone());
     }
 }
 

--- a/src/run/new.rs
+++ b/src/run/new.rs
@@ -109,9 +109,9 @@ fn cargo_generate_exe() -> Result<PathBuf> {
         ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
         _ => bail!("No cargo-generate tar binary found for {target_os} {target_arch}"),
     };
-    let url = format!("https://github.com/cargo-generate/cargo-generate/releases/download/{version}/cargo-generate-{version}-{target}.tar.gz");
+    let url = format!("https://github.com/cargo-generate/cargo-generate/releases/download/v{version}/cargo-generate-v{version}-{target}.tar.gz");
 
-    let name = format!("cargo-generate-{version}");
+    let name = format!("cargo-generate-v{version}");
 
     match INSTALL_CACHE.download(true, &name, &[], &url) {
         Ok(None) => bail!("Unable to download cargo-generate for {target_os} {target_arch}"),


### PR DESCRIPTION
- Link to download `cargo-generate` binaries had incorrect URL
  - This caused an issue when `cargo-generate` was not installed in PATH (via `cargo install cargo-generate)`
- Arguments for `cargo-generate` 
  - Missing `generate` argument (it's also needed when invoking the command from PATH `~/.cargo/bin/cargo-generate generate`)
  - `--name test` should be send to  `["--name", "test"]`