### PR TITLE
`binary-install` replacement, resolves #24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,22 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
 
 [[package]]
 name = "ahash"
@@ -63,16 +66,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
+name = "ar"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
 
 [[package]]
 name = "async-trait"
@@ -153,21 +150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,38 +175,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "binary-install"
-version = "0.0.2"
+name = "base64ct"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bc5f8c50dd6a80d0b303ddab79f42ddcb52fd43d68107ecf622c551fd4cd4"
-dependencies = [
- "curl",
- "dirs",
- "failure",
- "flate2",
- "hex",
- "is_executable",
- "siphasher 0.2.3",
- "tar",
- "zip",
-]
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -335,9 +295,10 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "axum",
- "binary-install",
  "cargo_metadata",
  "clap",
+ "decompress",
+ "dirs",
  "flexi_logger",
  "lazy_static",
  "lightningcss",
@@ -345,6 +306,7 @@ dependencies = [
  "notify",
  "once_cell",
  "regex",
+ "reqwest",
  "seahash",
  "serde",
  "serde_json",
@@ -385,6 +347,9 @@ name = "cc"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -408,9 +373,18 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -491,6 +465,16 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -594,36 +578,6 @@ checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
  "syn",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.59+curl-7.86.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -734,6 +688,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "decompress"
+version = "0.1.0"
+source = "git+https://github.com/rusty-ferris-club/decompress#a810fcab19901d89cfc9fc1d9102a7a1bfa74e47"
+dependencies = [
+ "ar",
+ "bzip2",
+ "flate2",
+ "lazy_static",
+ "regex",
+ "tar",
+ "thiserror",
+ "xz",
+ "zip",
+ "zstd 0.12.0+zstd.1.5.2",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,13 +756,23 @@ checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
  "redox_users",
@@ -820,25 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "failure"
-version = "0.1.8"
+name = "encoding_rs"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -858,15 +826,15 @@ checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -894,6 +862,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -955,6 +938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,8 +962,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1022,16 +1013,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1067,10 +1071,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.3.2"
+name = "hmac"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1122,6 +1129,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1133,6 +1141,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1182,6 +1203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,13 +1251,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_executable"
-version = "0.1.2"
+name = "ipnet"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d553b8abc8187beb7d663e34c065ac4570b273bc9511a50e940e99409c577"
-dependencies = [
- "winapi 0.3.9",
-]
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itertools"
@@ -1242,6 +1270,15 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1285,18 +1322,6 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lightningcss"
@@ -1345,6 +1370,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1398,9 +1434,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1458,6 +1494,24 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1535,19 +1589,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1557,9 +1634,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -1629,9 +1706,32 @@ checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -1710,7 +1810,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher 0.3.10",
+ "siphasher",
 ]
 
 [[package]]
@@ -1719,7 +1819,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher 0.3.10",
+ "siphasher",
 ]
 
 [[package]]
@@ -1947,12 +2047,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
@@ -1962,13 +2056,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "getrandom 0.2.8",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -2007,6 +2101,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,18 +2160,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2112,6 +2231,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2189,6 +2331,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,12 +2369,6 @@ checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "siphasher"
@@ -2276,6 +2434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,18 +2455,6 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
 
 [[package]]
 name = "tar"
@@ -2324,7 +2476,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2367,6 +2519,33 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -2416,6 +2595,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +2627,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2595,12 +2785,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
@@ -2764,6 +2948,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,6 +3050,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1844f66a2bc8526d71690104c0e78a8e59ffa1597b7245769d174ebb91deb5"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3011,6 +3217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,15 +3309,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "zip"
-version = "0.5.13"
+name = "xz"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
 dependencies = [
+ "xz2",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "aes",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
- "time",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.17",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.0+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8148aa921e9d53217ab9322f8553bd130f7ae33489db68b381d76137d2e6374"
+dependencies = [
+ "zstd-safe 6.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.4+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+dependencies = [
+ "cc",
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ tower-http = { version = "0.3", features = ["fs"] }
 notify = "4.0"
 lazy_static = "1.4"
 regex = "1.7"
-binary-install = "0.0.2"
 which = "4.3"
 cargo_metadata = { version = "0.15", features = ["builder"] }
 serde_json = "1.0"
@@ -34,3 +33,11 @@ wasm-bindgen-cli-support = "0.2"
 ansi_term = "0.12"
 once_cell = "1.16"
 seahash = "4.1"
+reqwest = { version = "0.11", features = [
+	"blocking",
+	"__tls",
+	"default-tls",
+	"native-tls-crate",
+], default-features = false }
+dirs = "4.0.0"
+decompress = { git = "https://github.com/rusty-ferris-club/decompress" }

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -8,7 +8,7 @@ use std::{fs, io::Cursor, path::PathBuf};
 use super::util::os_arch;
 
 lazy_static::lazy_static! {
-    static ref CACHE_DIR: PathBuf = get_cache_dir(".cargo-leptos").expect("Can not get cache directory");
+    static ref CACHE_DIR: PathBuf = get_cache_dir("cargo-leptos").expect("Can not get cache directory");
 }
 
 pub enum Exe {
@@ -30,13 +30,10 @@ impl ExeMeta {
     }
 
     fn get_name(&self) -> String {
-        let version_hash = seahash::hash(&self.version.as_bytes());
-        format!("{}-{}", &self.name, version_hash)
+        format!("{}-{}", &self.name, &self.version)
     }
 
     /// Returns an absolute path to be used for the binary.
-    ///
-    /// `BINARY_NAME-VERSION_HASH` -> `cargo-generate-2101299161167296450`
     fn get_exe_dir_path(&self) -> PathBuf {
         CACHE_DIR.join(self.get_name())
     }

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -1,0 +1,286 @@
+use crate::ext::anyhow::{bail, Result};
+use axum::body::Bytes;
+use decompress::decompressors;
+use regex::Regex;
+use std::{fs, io::Cursor, path::PathBuf};
+
+use super::util::os_arch;
+
+lazy_static::lazy_static! {
+    static ref CACHE_DIR: PathBuf = get_cache_dir(".cargo-leptos").expect("Can not get cache directory");
+}
+
+pub enum Exe {
+    CargoGenerate,
+    Sass,
+    WasmOpt,
+}
+
+struct ExeMeta {
+    name: String,
+    version: String,
+    get_exe_archive_url: fn(version: &str, target_os: &str, target_arch: &str) -> Result<String>,
+    // get_path_to_exe: Option<fn(target_os: &str) -> Vec<String>>,
+    get_exe_name: fn(target_os: &str) -> String,
+}
+
+impl ExeMeta {
+    fn exe_in_global_path(&self) -> Option<PathBuf> {
+        which::which(&self.name).ok()
+    }
+
+    fn get_name(&self) -> String {
+        let version_hash = seahash::hash(&self.version.as_bytes());
+        format!("{}-{}", &self.name, version_hash)
+    }
+
+    /// Returns an absolute path to be used for the binary.
+    ///
+    /// `BINARY_NAME-VERSION_HASH` -> `cargo-generate-2101299161167296450`
+    fn get_exe_dir_path(&self) -> PathBuf {
+        CACHE_DIR.join(self.get_name())
+    }
+
+    fn exe_in_cache(&self) -> Option<PathBuf> {
+        let (target_os, _) = os_arch().unwrap();
+
+        if !self.get_exe_dir_path().exists() {
+            return None;
+        }
+
+        let exe_name = &self.get_exe_name;
+        let exe_name = exe_name(target_os);
+
+        let exe_path = self.get_exe_dir_path().join(PathBuf::from(exe_name));
+
+        if !exe_path.exists() {
+            return None;
+        }
+
+        Some(exe_path)
+    }
+
+    fn get_download_url(&self) -> String {
+        let (target_os, target_arch) = os_arch().unwrap();
+        let url = &self.get_exe_archive_url;
+        let url = url(&self.version, target_os, target_arch).unwrap();
+
+        url
+    }
+
+    async fn fetch_archive(&self) -> Result<Bytes> {
+        let data = reqwest::get(self.get_download_url()).await?.bytes().await?;
+        Ok(data)
+    }
+
+    fn extract_archive(&self, data: &Bytes) -> Result<()> {
+        // let (target_os, _) = os_arch()?;
+        let name = self.get_name();
+
+        let url = self.get_download_url();
+
+        let ext = match url {
+            url if url.ends_with(".tar.gz") => "tar.gz",
+            url if url.ends_with(".zip") => "zip",
+            _ => bail!("The download URL does not contain either '.tar.gz' or '.zip' extension"),
+        };
+
+        let temp_file_path = CACHE_DIR.join(format!("tmp-{}.{}", name, ext));
+        let dest_dir = &self.get_exe_dir_path();
+
+        let mut temp_file = std::fs::File::create(&temp_file_path)?;
+        let mut content = Cursor::new(data);
+        std::io::copy(&mut content, &mut temp_file)?;
+
+        let extractor = decompress::Decompress::build(vec![
+            decompressors::zip::Zip::build(Some(Regex::new(r".*\.zip").unwrap())),
+            decompressors::targz::Targz::build(Some(Regex::new(r".*\.tar\.gz").unwrap())),
+        ]);
+
+        extractor.decompress(
+            &temp_file_path,
+            dest_dir,
+            &decompress::ExtractOpts { strip: 1 },
+        )?;
+
+        // let get_path_to_exe = &self.get_path_to_exe;
+
+        // match get_path_to_exe {
+        //     Some(get_path_to_exe) => {
+        //         let executables = get_path_to_exe(target_os);
+
+        //         for e in executables {
+        //             let source_path = dest_dir.join(&e);
+
+        //             let file_name = source_path.as_path().file_name().unwrap();
+        //             let dest_path = dest_dir.join(&file_name);
+
+        //             println!("paaath {:?}", source_path);
+        //             println!("dest_dir {:?}", dest_dir);
+
+        //             if !source_path.exists() {
+        //                 bail!(
+        //                     "Did not find executable {} in the extracted archive at {}",
+        //                     e,
+        //                     dest_dir.to_str().unwrap()
+        //                 );
+        //             }
+
+        //             // If file already exists, do not move it, it's already in the root.
+        //             if dest_path.as_path().exists() {
+        //                 continue;
+        //             }
+
+        //             println!("file {:?}", &source_path);
+        //             println!("move to {:?}", &dest_dir);
+
+        //             fs::copy(&source_path, dest_path)?;
+        //             fs::remove_file(source_path)?;
+        //         }
+        //     }
+        //     None => {}
+        // }
+        // Rename the root executable directory
+        fs::remove_file(&temp_file_path)?;
+
+        Ok(())
+    }
+
+    async fn download_exe(&self) -> Result<PathBuf> {
+        let data = self.fetch_archive().await?;
+        self.extract_archive(&data)?;
+
+        if let Some(binary_path) = self.exe_in_cache() {
+            Ok(binary_path)
+        } else {
+            bail!("Something went wrong")
+        }
+    }
+}
+
+pub async fn get_exe(app: Exe) -> Result<PathBuf> {
+    let exe = get_executable(app).unwrap();
+
+    if let Some(path) = exe.exe_in_global_path() {
+        return Ok(path);
+    }
+
+    if let Some(path) = exe.exe_in_cache() {
+        return Ok(path);
+    }
+
+    let path = exe.download_exe().await?;
+
+    log::debug!(
+        "{} (version {}) using executable at: {:?}",
+        exe.name,
+        exe.version,
+        path
+    );
+
+    Ok(path)
+}
+
+/// Returns the absolute path to app cache directory.
+///
+/// May return an error when system cache directory does not exist,
+/// or when it can not create app specific directory.
+///
+/// | OS       | Example                            |
+/// | -------- | ---------------------------------- |
+/// | Linux    | /home/alice/.cache/.NAME           |
+/// | macOS    | /Users/Alice/Library/Caches/.NAME  |
+/// | Windows  | C:\Users\Alice\AppData\Local\.NAME |
+fn get_cache_dir(name: &str) -> Result<PathBuf> {
+    let os_cache_dir = match dirs::cache_dir() {
+        Some(d) => d,
+        None => bail!("Cache directory does not exist"),
+    };
+
+    let cache_dir = os_cache_dir.join(name);
+
+    if !cache_dir.exists() {
+        fs::create_dir(&cache_dir)?;
+    }
+
+    Ok(cache_dir)
+}
+
+fn get_executable(app: Exe) -> Result<ExeMeta> {
+    let exe = match app {
+        Exe::CargoGenerate => ExeMeta {
+            name: "cargo-generate".to_string(),
+            version: "0.17.3".to_string(),
+            get_exe_archive_url: |version, target_os, target_arch| {
+                let target = match (target_os, target_arch) {
+                    ("macos", "aarch64") => "aarch64-apple-darwin",
+                    ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+                    ("macos", "x86_64") => "x86_64-apple-darwin",
+                    ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+                    ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
+                    _ => bail!("No cargo-generate tar binary found for {target_os} {target_arch}"),
+                };
+
+                let url = format!("https://github.com/cargo-generate/cargo-generate/releases/download/v{version}/cargo-generate-v{version}-{target}.tar.gz");
+                Ok(url)
+            },
+            // get_path_to_exe: None,
+            get_exe_name: |target_os| match target_os {
+                "windows" => "cargo-generate.exe".to_string(),
+                _ => "cargo-generate".to_string(),
+            },
+        },
+        Exe::Sass => ExeMeta {
+            name: "sass".to_string(),
+            version: "1.56.1".to_string(),
+            get_exe_archive_url: |version, target_os, target_arch| {
+                let url = match (target_os, target_arch) {
+                    ("windows", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-windows-x64.zip"),
+                    ("macos" | "linux", "x86_64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-x64.tar.gz"),
+                    ("macos" | "linux", "aarch64") => format!("https://github.com/sass/dart-sass/releases/download/{version}/dart-sass-{version}-{target_os}-arm64.tar.gz"),
+                    _ => bail!("No sass tar binary found for {target_os} {target_arch}")
+                };
+                Ok(url)
+            },
+            // get_path_to_exe: Some(|target_os| match target_os {
+            //     "windows" => vec![
+            //         "sass.bat".to_string(),
+            //         "src/dart.exe".to_string(),
+            //         "src/sass.snapshot".to_string(),
+            //     ],
+            //     "macos" => vec![
+            //         "sass".to_string(),
+            //         "src/dart".to_string(),
+            //         "src/sass.snapshot".to_string(),
+            //     ],
+            //     _ => vec!["sass".to_string()],
+            // }),
+            get_exe_name: |target_os| match target_os {
+                "windows" => "sass.bat".to_string(),
+                _ => "sass".to_string(),
+            },
+        },
+        Exe::WasmOpt => ExeMeta {
+            name: "wasm-opt".to_string(),
+            version: "version_111".to_string(),
+            get_exe_archive_url: |version, target_os, target_arch| {
+                let target = match (target_os, target_arch) {
+                    ("linux", _) => "x86_64-linux",
+                    ("windows", _) => "x86_64-windows",
+                    ("macos", "aarch64") => "arm64-macos",
+                    ("macos", "x86_64") => "x86_64-macos",
+                    _ => bail!("No wasm-opt tar binary found for {target_os} {target_arch}"),
+                };
+                let url = format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target}.tar.gz");
+                Ok(url)
+            },
+            // get_path_to_exe: None,
+            get_exe_name: |target_os| match target_os {
+                "windows" => "bin/wasm-opt.exe".to_string(),
+                _ => "bin/wasm-opt".to_string(),
+            },
+        },
+    };
+
+    Ok(exe)
+}

--- a/src/ext/exe.rs
+++ b/src/ext/exe.rs
@@ -20,7 +20,6 @@ struct ExeMeta {
     name: String,
     version: String,
     get_exe_archive_url: fn(version: &str, target_os: &str, target_arch: &str) -> Result<String>,
-    // get_path_to_exe: Option<fn(target_os: &str) -> Vec<String>>,
     get_exe_name: fn(target_os: &str) -> String,
 }
 
@@ -74,7 +73,6 @@ impl ExeMeta {
     }
 
     fn extract_archive(&self, data: &Bytes) -> Result<()> {
-        // let (target_os, _) = os_arch()?;
         let name = self.get_name();
 
         let url = self.get_download_url();
@@ -103,43 +101,6 @@ impl ExeMeta {
             &decompress::ExtractOpts { strip: 1 },
         )?;
 
-        // let get_path_to_exe = &self.get_path_to_exe;
-
-        // match get_path_to_exe {
-        //     Some(get_path_to_exe) => {
-        //         let executables = get_path_to_exe(target_os);
-
-        //         for e in executables {
-        //             let source_path = dest_dir.join(&e);
-
-        //             let file_name = source_path.as_path().file_name().unwrap();
-        //             let dest_path = dest_dir.join(&file_name);
-
-        //             println!("paaath {:?}", source_path);
-        //             println!("dest_dir {:?}", dest_dir);
-
-        //             if !source_path.exists() {
-        //                 bail!(
-        //                     "Did not find executable {} in the extracted archive at {}",
-        //                     e,
-        //                     dest_dir.to_str().unwrap()
-        //                 );
-        //             }
-
-        //             // If file already exists, do not move it, it's already in the root.
-        //             if dest_path.as_path().exists() {
-        //                 continue;
-        //             }
-
-        //             println!("file {:?}", &source_path);
-        //             println!("move to {:?}", &dest_dir);
-
-        //             fs::copy(&source_path, dest_path)?;
-        //             fs::remove_file(source_path)?;
-        //         }
-        //     }
-        //     None => {}
-        // }
         // Rename the root executable directory
         fs::remove_file(&temp_file_path)?;
 
@@ -224,7 +185,6 @@ fn get_executable(app: Exe) -> Result<ExeMeta> {
                 let url = format!("https://github.com/cargo-generate/cargo-generate/releases/download/v{version}/cargo-generate-v{version}-{target}.tar.gz");
                 Ok(url)
             },
-            // get_path_to_exe: None,
             get_exe_name: |target_os| match target_os {
                 "windows" => "cargo-generate.exe".to_string(),
                 _ => "cargo-generate".to_string(),
@@ -242,19 +202,6 @@ fn get_executable(app: Exe) -> Result<ExeMeta> {
                 };
                 Ok(url)
             },
-            // get_path_to_exe: Some(|target_os| match target_os {
-            //     "windows" => vec![
-            //         "sass.bat".to_string(),
-            //         "src/dart.exe".to_string(),
-            //         "src/sass.snapshot".to_string(),
-            //     ],
-            //     "macos" => vec![
-            //         "sass".to_string(),
-            //         "src/dart".to_string(),
-            //         "src/sass.snapshot".to_string(),
-            //     ],
-            //     _ => vec!["sass".to_string()],
-            // }),
             get_exe_name: |target_os| match target_os {
                 "windows" => "sass.bat".to_string(),
                 _ => "sass".to_string(),
@@ -274,7 +221,6 @@ fn get_executable(app: Exe) -> Result<ExeMeta> {
                 let url = format!("https://github.com/WebAssembly/binaryen/releases/download/{version}/binaryen-{version}-{target}.tar.gz");
                 Ok(url)
             },
-            // get_path_to_exe: None,
             get_exe_name: |target_os| match target_os {
                 "windows" => "bin/wasm-opt.exe".to_string(),
                 _ => "bin/wasm-opt".to_string(),

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -1,4 +1,5 @@
 pub mod anyhow;
+pub mod exe;
 pub mod fs;
 pub mod path;
 pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ mod run;
 use ext::{fs, path, sync, util};
 
 use crate::ext::anyhow::{Context, Result};
-use binary_install::Cache;
 use clap::{Parser, Subcommand, ValueEnum};
 use config::Config;
 use ext::path::PathBufExt;
@@ -14,10 +13,6 @@ use ext::sync::{send_reload, src_or_style_change, wait_for, Msg, MSG_BUS, SHUTDO
 use run::{assets, cargo, end2end, new, reload, sass, serve, wasm, watch, Html};
 use std::{env, path::PathBuf};
 use tokio::signal;
-
-lazy_static::lazy_static! {
-    pub static ref INSTALL_CACHE: Cache = Cache::new("cargo-leptos").unwrap();
-}
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Log {


### PR DESCRIPTION
Intial implementation.
I've tested it on Windows 11 only (no macOS and Linux yet). But I'm fairly confident it will work fine.

I found a new crate [`decompress`](https://github.com/rusty-ferris-club/decompress) for extracting archives. I struggled to find any other good alternative.

In works fine but I'm not happy with the code yet.
Hopefully in couple of days the PR will be ready.

Any feedback is appriciated!
