### PR TITLE
Fix for single-package setup not triggering rebuild on edits

### DIFF
--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -85,7 +85,11 @@ impl BinPackage {
         };
 
         let mut src_paths = metadata.src_path_dependencies(&package.id);
-        src_paths.push(rel_dir.join("src").unbase(&rel_dir).expect("rel_dir should contain itself, it did not"));
+        if rel_dir == "." {
+            src_paths.push("src".into());
+        } else {
+            src_paths.push(rel_dir.join("src"));
+        }
         Ok(Self {
             name,
             abs_dir,

--- a/src/config/bin_package.rs
+++ b/src/config/bin_package.rs
@@ -85,7 +85,7 @@ impl BinPackage {
         };
 
         let mut src_paths = metadata.src_path_dependencies(&package.id);
-        src_paths.push(rel_dir.join("src"));
+        src_paths.push(rel_dir.join("src").unbase(&rel_dir).expect("rel_dir should contain itself, it did not"));
         Ok(Self {
             name,
             abs_dir,

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -79,7 +79,11 @@ impl LibPackage {
         };
 
         let mut src_deps = metadata.src_path_dependencies(&package.id);
-        src_deps.push(rel_dir.join("src").unbase(&rel_dir).expect("rel_dir should contain itself, it did not"));
+        if rel_dir == "." {
+            src_deps.push("src".into());
+        } else {
+            src_deps.push(rel_dir.join("src"));
+        }
         Ok(Self {
             name,
             abs_dir,

--- a/src/config/lib_package.rs
+++ b/src/config/lib_package.rs
@@ -79,7 +79,7 @@ impl LibPackage {
         };
 
         let mut src_deps = metadata.src_path_dependencies(&package.id);
-        src_deps.push(rel_dir.join("src"));
+        src_deps.push(rel_dir.join("src").unbase(&rel_dir).expect("rel_dir should contain itself, it did not"));
         Ok(Self {
             name,
             abs_dir,

--- a/src/config/snapshots/cargo_leptos__config__tests__project.snap
+++ b/src/config/snapshots/cargo_leptos__config__tests__project.snap
@@ -23,7 +23,7 @@ Config {
                 ],
                 default_features: false,
                 output_name: "example",
-                src_paths: "./src",
+                src_paths: "src",
                 ..
             },
             bin: BinPackage {
@@ -35,7 +35,7 @@ Config {
                     "ssr",
                 ],
                 default_features: false,
-                src_paths: "./src",
+                src_paths: "src",
                 ..
             },
             style: Some(


### PR DESCRIPTION
In src/config/bin_package.rs and in src/config/lib_package.rs
Calling `rel_dir.join("src")` was appending:
  `.\\src` on Windows
  `./src` on Linux

The rest of the parsed folders are formatted without the leading ./ or .\\\\ leading to nothing ever being a "watched" item.

Changing the join to match how other directories are parsed gives:
`rel_dir.join("src").unbase(&rel_dir).expect()`

